### PR TITLE
eslint fix: 'cwd' is assigned a value but never used

### DIFF
--- a/test/ConfigFile.spec.js
+++ b/test/ConfigFile.spec.js
@@ -52,7 +52,6 @@ const JSON_INVALID_CONFIG_FILE = '{ERROR}';
 const YML_INVALID_CONFIG_FILE = `
 ERROR
 `;
-const cwd = process.cwd();
 
 // Mocks
 const mockFileSystem = () => {


### PR DESCRIPTION
Removed cwd that was not being used